### PR TITLE
Fix connectable flag.

### DIFF
--- a/src/ble_manager.cc
+++ b/src/ble_manager.cc
@@ -148,7 +148,7 @@ void BLEManager::OnScanResult(BluetoothLEAdvertisementWatcher watcher,
     else
     {
         PeripheralWinrt& peripheral = mDeviceMap[uuid];
-        peripheral.Update(rssi, args.Advertisement());
+        peripheral.Update(rssi, args.Advertisement(), advertismentType);
         if (mAllowDuplicates || mAdvertismentMap.find(uuid) == mAdvertismentMap.end())
         {
             mAdvertismentMap.insert(uuid);

--- a/src/peripheral_winrt.cc
+++ b/src/peripheral_winrt.cc
@@ -19,9 +19,7 @@ PeripheralWinrt::PeripheralWinrt(uint64_t bluetoothAddress,
     address = formatBluetoothAddress(bluetoothAddress);
     // Random addresses have the two most-significant bits set of the 48-bit address.
     addressType = (bluetoothAddress >= 211106232532992) ? RANDOM : PUBLIC;
-    connectable = advertismentType == BluetoothLEAdvertisementType::ConnectableUndirected ||
-        advertismentType == BluetoothLEAdvertisementType::ConnectableDirected;
-    Update(rssiValue, advertisment);
+    Update(rssiValue, advertisment, advertismentType);
 }
 
 PeripheralWinrt::~PeripheralWinrt()
@@ -32,13 +30,16 @@ PeripheralWinrt::~PeripheralWinrt()
     }
 }
 
-void PeripheralWinrt::Update(const int rssiValue, const BluetoothLEAdvertisement& advertisment)
+void PeripheralWinrt::Update(const int rssiValue, const BluetoothLEAdvertisement& advertisment, const BluetoothLEAdvertisementType& advertismentType)
 {
     std::string localName = ws2s(advertisment.LocalName().c_str());
     if (!localName.empty())
     {
         name = localName;
     }
+
+    connectable = advertismentType == BluetoothLEAdvertisementType::ConnectableUndirected ||
+        advertismentType == BluetoothLEAdvertisementType::ConnectableDirected;
 
     manufacturerData.clear();
     for (auto& ds : advertisment.DataSections())

--- a/src/peripheral_winrt.h
+++ b/src/peripheral_winrt.h
@@ -51,7 +51,7 @@ public:
                     int rssiValue, const BluetoothLEAdvertisement& advertisment);
     ~PeripheralWinrt();
 
-    void Update(int rssiValue, const BluetoothLEAdvertisement& advertisment);
+    void Update(int rssiValue, const BluetoothLEAdvertisement& advertisment, const BluetoothLEAdvertisementType& advertismentType);
 
     void Disconnect();
 

--- a/src/radio_watcher.h
+++ b/src/radio_watcher.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <functional>
 #include <set>
 #include <winrt/Windows.Devices.Enumeration.h>
 #include <winrt/Windows.Devices.Radios.h>


### PR DESCRIPTION
Recalc connectable flag per advertisement. It was previously pegged to the first seen value. 

